### PR TITLE
Fix Dockerfile comment punctuation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.n8n.io/n8nio/n8n:latest   # Official image – don’t reinvent it
+FROM docker.n8n.io/n8nio/n8n:latest   # Official image - don't reinvent it
 # Place for optional plugins or patches


### PR DESCRIPTION
## Summary
- replace typographic dash and apostrophe with ASCII versions in Dockerfile comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e8c75d518832f8fac8eb8735e417b